### PR TITLE
Reverse engineer primary key, domains and seperate types and sets

### DIFF
--- a/PowerDesigner_OData_AddIn/CrossBreeze.Tools.PowerDesigner.AddIn.OData.csproj
+++ b/PowerDesigner_OData_AddIn/CrossBreeze.Tools.PowerDesigner.AddIn.OData.csproj
@@ -72,6 +72,7 @@
       <DependentUpon>PdODataBasicAuthenticationForm.cs</DependentUpon>
     </Compile>
     <Compile Include="PdAppHelper.cs" />
+    <Compile Include="PdHelper.cs" />
     <Compile Include="PdLogger.cs" />
     <Compile Include="PdODataAddIn.cs" />
     <Compile Include="PdODataException.cs" />

--- a/PowerDesigner_OData_AddIn/PdHelper.cs
+++ b/PowerDesigner_OData_AddIn/PdHelper.cs
@@ -1,0 +1,61 @@
+﻿
+namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
+{
+    public static class PdHelper
+    {
+        public static PdPDM.Package GetOrCreatePackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
+        {
+            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
+            // If the package is found, return it.
+            if (pdmPackageObject != null)
+            {
+                return (PdPDM.Package)pdmPackageObject;
+            }
+            // If the package wasn't found, create it.
+            else
+            {
+                PdPDM.Package pdmPackage = (PdPDM.Package)pdmModel.Packages.CreateNew();
+                pdmPackage.Name = packageNameToFind;
+                pdmPackage.SetNameToCode();
+                pdmModel.Packages.Add(pdmPackage);
+                return pdmPackage;
+            }
+
+        }
+
+        public static PdPDM.Package GetPackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
+        {
+            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
+            // If the package is found, return it.
+            if (pdmPackageObject != null)
+            {
+                return (PdPDM.Package)pdmPackageObject;
+            }
+            // If the package wasn't found, return null.
+            return null;
+
+        }
+
+        public static PdPDM.Table GetTable(PdPDM.BasePackage model, string tableNameToFind)
+        {
+            // Find the table in the model.
+            var tableObject = model.FindChildByName(tableNameToFind, (int)PdPDM.PdPDM_Classes.cls_Table);
+            if (tableObject != null)
+                return (PdPDM.Table)tableObject;
+
+            // If the table wasn't found, return null.
+            return null;
+        }
+
+        public static PdPDM.View GetView(PdPDM.BasePackage model, string viewNameToFind)
+        {
+            // Find the view in the model.
+            var viewObject = model.FindChildByName(viewNameToFind, (int)PdPDM.PdPDM_Classes.cls_View);
+            if (viewObject != null)
+                return (PdPDM.View)viewObject;
+
+            // If the view wasn't found, return null.
+            return null;
+        }
+    }
+}

--- a/PowerDesigner_OData_AddIn/PdODataModelUpdater.cs
+++ b/PowerDesigner_OData_AddIn/PdODataModelUpdater.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Windows.Forms;
 using CrossBreeze.Tools.PowerDesigner.AddIn.OData.Forms;
+using PdCommon;
 
 namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
 {
@@ -85,6 +86,14 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
 
             // Create a new PDM model.
             PdPDM.Model oImportDataModel = (PdPDM.Model)this._app.CreateModel(((int)PdPDM.PdPDM_Classes.cls_Model), "", openFlags);
+            // Set base model options to be case senstive and mixed case.
+            PdPDM.ModelOptions modelOptions = (PdPDM.ModelOptions)oImportDataModel.GetModelOptions();
+            modelOptions.NameCodeCaseSensitive = true;
+            // Set all Code naming conventions character case to Mixed (M).
+            foreach (PdCommon.NamingConvention namingConvention in modelOptions.CodeNamingConventions)
+            {
+                namingConvention.CharacterCase = "M";
+            }
             // Set the name of the model.
             oImportDataModel.Name = pdmModelName;
             oImportDataModel.SetNameToCode();

--- a/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
+++ b/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Xml;
 
 using Microsoft.OData.Edm;
@@ -21,138 +24,288 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
             // Try to parse the uri to a edm model.
             if (CsdlReader.TryParse(oDataMetadataXmlReader, out IEdmModel model, out IEnumerable<EdmError> errors))
             {
-                // Loop through the schema elements in the model.
-                //_logger.Debug(string.Format("EntityContainer[Name={0}; Location={1}]", model.EntityContainer.Name, model.EntityContainer.Location()));
-                // Loop through the schema elements in the model.
-                foreach (IEdmEntityContainerElement entityContainerElement in model.EntityContainer.Elements)
+
+                // Create a list of type definitions.
+                IEnumerable<IEdmSchemaType> schemaTypeDefinitions = model.SchemaElements.Where(schemaElement => schemaElement.SchemaElementKind.Equals(EdmSchemaElementKind.TypeDefinition)).Cast<IEdmSchemaType>();
+
+                // First create the Domains based on the enum types.
+                logger.Debug("Adding domains from enums:");
+                foreach (IEdmEnumType enumType in schemaTypeDefinitions.Where(typeDefinition => typeDefinition.TypeKind.Equals(EdmTypeKind.Enum)))
                 {
-                    logger.Debug(string.Format(" EntityContainerElement[ContainerElementKind={0}; Name={1}; Location={2}]", Enum.GetName(typeof(EdmContainerElementKind), entityContainerElement.ContainerElementKind), entityContainerElement.Name, entityContainerElement.Location()));
-                    if (entityContainerElement.ContainerElementKind.Equals(EdmContainerElementKind.EntitySet))
+                    logger.Debug(string.Format(" Enum[Name={0}; Namespace={1}]", enumType.Name, enumType.Namespace));
+
+                    // Create a new PDM domain object for the Enum.
+                    PdPDM.PhysicalDomain pdmEnumDomain = (PdPDM.PhysicalDomain)pdmModel.Domains.CreateNew();
+                    pdmEnumDomain.Name = enumType.FullName();
+                    pdmEnumDomain.SetNameToCode();
+
+                    // Create the ListOfValues of the Domain based on the Enum members.
+                    // The list of values is stored in a formatted text.
+                    // The format is the following: Value1 '\t' Label1 '\n' Value2 '\t' Label2 '\n' ...
+                    // The Tabulation is used as a separator between the value and the value label.
+                    // The separator between each line is: '\n'.
+                    foreach (IEdmEnumMember enumMember in enumType.Members)
                     {
-                        IEdmEntitySet edmEntitySet = (IEdmEntitySet)entityContainerElement;
-                        logger.Debug(string.Format(" =EntitySet[ContainerElementKind={0}; Name={1}]", Enum.GetName(typeof(EdmContainerElementKind), edmEntitySet.ContainerElementKind), edmEntitySet.Name));
-                        IEdmEntityType entityType = edmEntitySet.EntityType();
-                        logger.Debug(string.Format(" =EntityType[Name={0}; IsAbstract={1}]", entityType.Name, entityType.IsAbstract));
+                        pdmEnumDomain.ListOfValues += string.Format("{0}\t{1}\n", enumMember.Value.Value, enumMember.Name);
+                    }
 
-                        // If the entity type is not abstract, create a table for it.
-                        if (!entityType.IsAbstract)
+                    // Add the domain to the model.
+                    pdmModel.Domains.Add(pdmEnumDomain);
+                }
+
+                // Then create all tables based on the Entity and Complex type definitions.
+                logger.Debug("Adding tables from entity and complex types:");
+                IEnumerable<IEdmSchemaType> structuredTypeElements = schemaTypeDefinitions.Where(typeDefinition => typeDefinition.TypeKind.Equals(EdmTypeKind.Entity) || typeDefinition.TypeKind.Equals(EdmTypeKind.Complex));
+                foreach (IEdmSchemaType structuredTypeElement in structuredTypeElements)
+                {
+                    logger.Debug(string.Format(" {0}[Name={1}; Namespace={2}]", Enum.GetName(typeof(EdmTypeKind), structuredTypeElement.TypeKind), structuredTypeElement.Name, structuredTypeElement.Namespace));
+
+                    // Get or create the package for the entity type.
+                    PdPDM.Package pdmTypePackage = GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
+
+                    // Create a new PDM table object for the EntityType.
+                    PdPDM.Table pdmTypeTable = (PdPDM.Table)pdmTypePackage.Tables.CreateNew();
+                    pdmTypeTable.Name = structuredTypeElement.Name;
+                    pdmTypeTable.SetNameToCode();
+
+                    // Add the columns to the table based on the declared properties.
+                    AddColumsToTable(pdmTypeTable, (IEdmStructuredType)structuredTypeElement, logger);
+
+                    // Add the table to the package.
+                    pdmTypePackage.Tables.Add(pdmTypeTable);
+                }
+
+                logger.Debug("Adding tables references:");
+                foreach (IEdmSchemaType structuredTypeElement in structuredTypeElements)
+                {
+                    // Find the table which represents the underlying type.
+                    PdPDM.Package pdmEntityTypePackage = GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
+                    if (pdmEntityTypePackage == null)
+                    {
+                        logger.Error(string.Format("The type package '{0}' was not found!", structuredTypeElement.Namespace));
+                        throw new PdODataException("The type package was not found!");
+                    }
+                    PdPDM.Table typeTable = GetTable(pdmEntityTypePackage, structuredTypeElement.Name);
+                    if (typeTable == null)
+                    {
+                        logger.Error(string.Format("The type table '{0}' was not found!", structuredTypeElement.Name));
+                        throw new PdODataException("The type table was not found!");
+                    }
+
+                    // Loop over the navigation properties of the schema type element.
+                    foreach (IEdmNavigationProperty navProp in ((IEdmStructuredType)structuredTypeElement).NavigationProperties())
+                    {
+                        logger.Debug(string.Format(" -IEdmNavigationProperty[Name={0}; PropertyKind={1}]", navProp.Name, Enum.GetName(typeof(EdmPropertyKind), navProp.PropertyKind)));
+
+                        IEdmEntityType targetedEntityType = navProp.ToEntityType();
+                        // Find the table which represents the targeted type.
+                        PdPDM.Package pdmTargetEntityTypePackage = GetOrCreatePackage(pdmModel, targetedEntityType.Namespace);
+                        if (pdmTargetEntityTypePackage == null)
                         {
-                            // Create a new PDM table object for the EntityType.
-                            PdPDM.Table pdmTable = (PdPDM.Table)pdmModel.Tables.CreateNew();
-                            pdmTable.Name = entityType.Name;
-                            pdmTable.SetNameToCode();
+                            logger.Error(string.Format("The targeted type package '{0}' was not found!", targetedEntityType.Namespace));
+                            throw new PdODataException("The targeted type package was not found!");
+                        }
+                        PdPDM.Table targetedTypeTable = GetTable(pdmTargetEntityTypePackage, targetedEntityType.Name);
+                        if (targetedTypeTable == null)
+                        {
+                            logger.Error(string.Format("The targeted type table '{0}' was not found!", targetedEntityType.Name));
+                            throw new PdODataException("The targeted type table was not found!");
+                        }
 
-                            // Loop overthe declared properties.
-                            foreach (IEdmProperty edmProperty in entityType.DeclaredProperties)
+                        logger.Debug("  -Creating table reference");
+
+                        PdPDM.Reference tableRef = (PdPDM.Reference)((PdPDM.BasePhysicalPackage)typeTable.Package).References.CreateNew();
+                        // Set the name of the reference based on the child, parent and parent role.
+                        tableRef.Name = string.Format("{0} > {1} : {2}", typeTable.Name, targetedTypeTable.Name, navProp.Name);
+                        tableRef.SetNameToCode();
+                        // Set the parent table and role.
+                        tableRef.ParentTable = targetedTypeTable;
+                        tableRef.ParentRole = navProp.Name;
+                        // Add the reference to the child table.
+                        typeTable.OutReferences.Add(tableRef);
+                    }
+                }
+
+
+                //logger.Debug(string.Format("EntityContainer[Name={0}; Location={1}]", model.EntityContainer.Name, model.EntityContainer.Location()));
+                // Loop through the entity elements in the model.
+                logger.Debug("Adding views from entity sets:");
+                IEnumerable<IEdmEntitySet> edmEntitySets = model.EntityContainer.Elements.Where(entityContainerElement => entityContainerElement.ContainerElementKind.Equals(EdmContainerElementKind.EntitySet)).Cast<IEdmEntitySet>();
+                foreach (IEdmEntitySet edmEntitySet in edmEntitySets)
+                {
+                    logger.Debug(string.Format(" EntitySet[ContainerElementKind={0}; Name={1}; Namespace={2}]", Enum.GetName(typeof(EdmContainerElementKind), edmEntitySet.ContainerElementKind), edmEntitySet.Name, edmEntitySet.Container.Namespace));
+
+                    IEdmEntityType entityType = edmEntitySet.EntityType();
+                    logger.Debug(string.Format(" =EntityType[Name={0}; IsAbstract={1}; Namespace={2}]", entityType.Name, entityType.IsAbstract, entityType.Namespace));
+
+                    // Now a table is created for the EntityType, we create a view for the EntitySet.
+                    // Find the schema to entity type belongs to, so the table can be added in the right package.
+                    PdPDM.Package pdmEntitySetPackage = GetOrCreatePackage(pdmModel, edmEntitySet.Container.Namespace);
+                    PdPDM.View pdmView = (PdPDM.View)pdmEntitySetPackage.Views.CreateNew();
+                    pdmView.Name = edmEntitySet.Name;
+                    pdmView.SetNameToCode();
+
+                    // Find the table which represents the underlying type.
+                    PdPDM.Package pdmEntityTypePackage = GetOrCreatePackage(pdmModel, entityType.Namespace);
+                    if (pdmEntityTypePackage == null)
+                    {
+                        logger.Error(string.Format("The type package '{0}' was not found!", entityType.Namespace));
+                        throw new PdODataException("The type package was not found!");
+                    }
+                    PdPDM.Table typeTable = GetTable(pdmEntityTypePackage, entityType.Name);
+                    if (typeTable == null)
+                    {
+                        logger.Error(string.Format("The type table '{0}' was not found!", entityType.Name));
+                        throw new PdODataException("The type table was not found!");
+                    }
+                    // Get a list of the column names.
+                    var colNames = from PdPDM.Column col in typeTable.Columns.Cast<PdPDM.Column>()
+                                    select string.Format("\"{0}\"", col.Name);
+                    pdmView.SQLQuery = string.Format("SELECT {0} FROM \"{1}\"", string.Join(",", colNames), typeTable.Name);
+                    pdmEntitySetPackage.Views.Add(pdmView);
+                }
+
+                // After we created the views we can create the view references between them.
+                logger.Debug("Adding view references:");
+                foreach (IEdmEntitySet edmEntitySet in edmEntitySets)
+                {
+                    logger.Debug(string.Format(" EntitySet[ContainerElementKind={0}; Name={1}; Namespace={2}]", Enum.GetName(typeof(EdmContainerElementKind), edmEntitySet.ContainerElementKind), edmEntitySet.Name, edmEntitySet.Container.Namespace));
+
+                    // Get the package for the view.
+                    PdPDM.Package pdmEntitySetPackage = GetPackage(pdmModel, edmEntitySet.Container.Namespace);
+                    if (pdmEntitySetPackage == null)
+                    {
+                        logger.Error(string.Format("The current package '{0}' was not found!", edmEntitySet.Container.Namespace));
+                        throw new PdODataException("The current package was not found!");
+                    } else
+                    {
+                        logger.Debug(string.Format(" -Package={0}", pdmEntitySetPackage.Name));
+                    }
+
+                    PdPDM.View currentView = GetView(pdmEntitySetPackage, edmEntitySet.Name);
+                    if (currentView == null)
+                    {
+                        logger.Error(string.Format("The current view '{0}' was not found!", edmEntitySet.Name));
+                        throw new PdODataException("The current view was not found!");
+                    } else
+                    {
+                        logger.Debug(string.Format(" -View={0}", currentView.Name));
+                    }
+
+                    // Loop throught the navigation property bindings.
+                    foreach (IEdmNavigationPropertyBinding navigationPropertyBinding in edmEntitySet.NavigationPropertyBindings)
+                    {
+                        logger.Debug(string.Format(" -IEdmNavigationPropertyBinding[Name={0}; Target={1}; TargetType={2}]", navigationPropertyBinding.NavigationProperty.Name, navigationPropertyBinding.Target.Name, Enum.GetName(typeof(EdmTypeKind), navigationPropertyBinding.Target.Type.TypeKind)));
+
+                        // Represents a type implementing Microsoft.OData.Edm.IEdmCollectionType.
+                        if (navigationPropertyBinding.Target.Type.TypeKind.Equals(EdmTypeKind.Collection))
+                        {
+                            PdPDM.View targetView = GetView(pdmEntitySetPackage, navigationPropertyBinding.Target.Name);
+                            if (targetView == null)
                             {
-                                logger.Debug(string.Format(" -Property[Name={0}; PropertyKind={1}; Type={2}]", edmProperty.Name, Enum.GetName(typeof(EdmPropertyKind), edmProperty.PropertyKind), edmProperty.Type.FullName()));
-
-                                // Only add columns for properties which are structural.
-                                if (edmProperty.PropertyKind.Equals(EdmPropertyKind.Structural))
-                                {
-                                    // Create a new columns for the property.
-                                    PdPDM.Column pdmColumn = (PdPDM.Column)pdmTable.Columns.CreateNew();
-                                    pdmColumn.Name = edmProperty.Name;
-                                    pdmColumn.SetNameToCode();
-
-                                    // If the EDM property is part of the key, set the Primary indicator to true.
-                                    if (edmProperty.IsKey())
-                                        pdmColumn.Primary = true;
-
-                                    // If the type is set, update the column.
-                                    if (edmProperty.Type != null)
-                                    {
-                                        SetColumnType(pdmColumn, edmProperty.Type, logger);
-                                    }
-
-                                    // Add the new columns to the columns collection.
-                                    pdmTable.Columns.Add(pdmColumn);
-                                }
-                                // TODO: Handle references at the end of creating the model. You cannot create references while handling entities, since the target entity might not exist yet.
-                                /**else if (edmProperty.PropertyKind.Equals(EdmPropertyKind.Navigation))
-                                {
-                                    logger.Debug(string.Format("Found navigation property {0}", edmProperty.Name));
-
-                                    // If the type is not set, skip this property.
-                                    string foreignEntityName = ((IEdmNavigationProperty)edmProperty).ToEntityType().Name;
-                                    if (edmProperty.Type == null)
-                                        break;
-                                    logger.Debug(string.Format("Found foreign entity {0}", foreignEntityName));
-
-                                    PdPDM.Reference fkReference = (PdPDM.Reference)pdmTable.OutReferences.CreateNew();
-                                    fkReference.Name = edmProperty.Name;
-                                    fkReference.SetNameToCode();
-
-                                    // Search for the foreign table.
-                                    PdPDM.Table foreignPdmTable = null;
-                                    foreach (PdPDM.Table possibleForeignTable in pdmModel.Tables)
-                                    {
-                                        if (possibleForeignTable.Name.Equals(foreignEntityName))
-                                        {
-                                            foreignPdmTable = possibleForeignTable;
-                                            break;
-                                        }
-                                    }
-                                    if (foreignPdmTable == null)
-                                    {
-                                        logger.Error("The foreign table was not found!");
-                                        throw new PdODataException("The foreign table was not found!");
-                                    }
-
-                                    foreach (EdmReferentialConstraintPropertyPair referentialConstraintPropertyPair in ((IEdmNavigationProperty)edmProperty).ReferentialConstraint.PropertyPairs)
-                                    {
-                                        IEdmStructuralProperty localProperty = referentialConstraintPropertyPair.DependentProperty;
-                                        IEdmStructuralProperty foreignProperty = referentialConstraintPropertyPair.PrincipalProperty;
-                                        logger.Debug(string.Format("Found referential constraint property pair for local property {0} to foreign property {1}", localProperty.Name, foreignProperty.Name));
-
-                                        PdPDM.Column localColumn = null;
-                                        // Find the local PDM column.
-                                        foreach (PdPDM.Column pdmColumn in pdmTable.Columns)
-                                        {
-                                            if (pdmColumn.Name.Equals(localProperty.Name))
-                                            {
-                                                localColumn = pdmColumn;
-                                                break;
-                                            }
-                                        }
-                                        if (localColumn == null)
-                                        {
-                                            logger.Error("The local column was not found!");
-                                            throw new PdODataException("The local column was not found!");
-                                        }
-
-                                        PdPDM.Column foreignColumn = null;
-                                        // Find the foreign PDM column.
-                                        foreach (PdPDM.Column pdmColumn in foreignPdmTable.Columns)
-                                        {
-                                            if (pdmColumn.Name.Equals(foreignProperty.Name))
-                                            {
-                                                foreignColumn = pdmColumn;
-                                                break;
-                                            }
-                                        }
-                                        if (foreignColumn == null)
-                                        {
-                                            logger.Error("The foreign column was not found!");
-                                            throw new PdODataException("The foreign column was not found!");
-                                        }
-
-                                        PdPDM.ReferenceJoin referenceJoin = (PdPDM.ReferenceJoin)fkReference.Joins.CreateNew();
-                                        referenceJoin.ChildTableColumn = localColumn;
-                                        referenceJoin.ParentTableColumn = foreignColumn;
-                                        fkReference.Joins.Add(referenceJoin);
-                                    }
-
-                                    pdmTable.OutReferences.Add(fkReference);
-                                }*/
-
+                                logger.Error(string.Format("The target view '{0}' was not found!", navigationPropertyBinding.Target.Name));
+                                throw new PdODataException("The target view was not found!");
                             }
-
-                            // Add the new table to the tables collection.
-                            pdmModel.Tables.Add(pdmTable);
+                            else
+                            {
+                                logger.Debug(" -Creating table reference:");
+                                logger.Debug(string.Format("  -TargetView={0}", targetView.Name));
+                                PdPDM.ViewReference viewReference = (PdPDM.ViewReference)pdmEntitySetPackage.ViewReferences.CreateNew();
+                                viewReference.Name = string.Format("{0} > {1} : {2}", currentView.Name, targetView.Name, navigationPropertyBinding.NavigationProperty.Name);
+                                viewReference.SetNameToCode();
+                                // Set the parent to the view.
+                                viewReference.Object2 = targetView;
+                                viewReference.ParentRole = navigationPropertyBinding.NavigationProperty.Name;
+                                // Add the reference to the view.
+                                currentView.OutViewReferences.Add(viewReference);
+                            }
                         }
                     }
                 }
+
+                //foreach (Tuple<IEdmEntityContainerElement, IEdmNavigationPropertyBinding> edmNavigationPropertyBindingTuple in model.EntityContainer.GetNavigationPropertyBindings())
+                //{
+                //    IEdmNavigationPropertyBinding edmNavigationPropertyBinding = edmNavigationPropertyBindingTuple.Item2;
+                //    IEdmNavigationProperty edmNavigationProperty = edmNavigationPropertyBinding.NavigationProperty;
+                //    string targetViewName = edmNavigationPropertyBinding.Target.Name;
+                //    logger.Debug(string.Format("Found navigation property binding '{0}'; Target={1}; Type={2}", edmNavigationProperty.Name, targetViewName, Enum.GetName(typeof(EdmTypeKind), edmNavigationPropertyBinding.Target.Type.TypeKind)));
+
+                //    // Represents a type implementing Microsoft.OData.Edm.IEdmCollectionType.
+                //    if (edmNavigationPropertyBinding.Target.Type.TypeKind.Equals(EdmTypeKind.Collection))
+                //    {
+                //        IEdmCollectionType collectionType = (IEdmCollectionType)edmNavigationPropertyBinding.Target.Type;
+                //        logger.Debug(string.Format(" =IEdmCollection[ElementType={0}", Enum.GetName(typeof(EdmTypeKind), collectionType.ElementType.TypeKind())));
+                //    }
+
+                    //PdPDM.View targetView = GetView(pdmModel, targetViewName);
+                    //if (targetView == null)
+                    //{
+                    //    logger.Error(string.Format("The target view '{0}' was not found!", targetViewName));
+                    //    throw new PdODataException("The target view was not found!");
+                    //}
+
+                    //// If the type is not set, skip this property.
+                    //string foreignEntityName = edmNavigationProperty.ToEntityType().Name;
+                    //logger.Debug(string.Format("Found foreign entity {0}", foreignEntityName));
+
+                    //PdPDM.View foreignView = GetView(pdmModel, foreignEntityName);
+                    //if (foreignView == null)
+                    //{
+                    //    logger.Error(string.Format("The foreign view '{0}' was not found!", foreignEntityName));
+                    //    throw new PdODataException("The foreign view was not found!");
+                    //}
+
+                    //PdPDM.ViewReference fkReference = (PdPDM.ViewReference)targetView.OutViewReferences.CreateNew();
+                    //fkReference.Name = edmNavigationProperty.Name;
+                    //fkReference.SetNameToCode();
+
+                    //foreach (EdmReferentialConstraintPropertyPair referentialConstraintPropertyPair in ((IEdmNavigationProperty)edmProperty).ReferentialConstraint.PropertyPairs)
+                    //{
+                    //    IEdmStructuralProperty localProperty = referentialConstraintPropertyPair.DependentProperty;
+                    //    IEdmStructuralProperty foreignProperty = referentialConstraintPropertyPair.PrincipalProperty;
+                    //    logger.Debug(string.Format("Found referential constraint property pair for local property {0} to foreign property {1}", localProperty.Name, foreignProperty.Name));
+
+                    //    PdPDM.Column localColumn = null;
+                    //    // Find the local PDM column.
+                    //    foreach (PdPDM.Column pdmColumn in pdmTable.Columns)
+                    //    {
+                    //        if (pdmColumn.Name.Equals(localProperty.Name))
+                    //        {
+                    //            localColumn = pdmColumn;
+                    //            break;
+                    //        }
+                    //    }
+                    //    if (localColumn == null)
+                    //    {
+                    //        logger.Error("The local column was not found!");
+                    //        throw new PdODataException("The local column was not found!");
+                    //    }
+
+                    //    PdPDM.Column foreignColumn = null;
+                    //    // Find the foreign PDM column.
+                    //    foreach (PdPDM.Column pdmColumn in foreignPdmTable.Columns)
+                    //    {
+                    //        if (pdmColumn.Name.Equals(foreignProperty.Name))
+                    //        {
+                    //            foreignColumn = pdmColumn;
+                    //            break;
+                    //        }
+                    //    }
+                    //    if (foreignColumn == null)
+                    //    {
+                    //        logger.Error("The foreign column was not found!");
+                    //        throw new PdODataException("The foreign column was not found!");
+                    //    }
+
+                    //    PdPDM.ReferenceJoin referenceJoin = (PdPDM.ReferenceJoin)fkReference.Joins.CreateNew();
+                    //    referenceJoin.ChildTableColumn = localColumn;
+                    //    referenceJoin.ParentTableColumn = foreignColumn;
+                    //    fkReference.Joins.Add(referenceJoin);
+                    //}
+
+                    //targetView.OutViewReferences.Add(fkReference);
+                //}
+
             }
             // If an error occurred while trying to parse the edm model, log the error(s).
             else
@@ -163,6 +316,99 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                     logger.Error(string.Format(" [{0}] {1} @{2}", edmError.ErrorCode, edmError.ErrorMessage, edmError.ErrorLocation));
                 }
             }
+        }
+
+        public static void AddColumsToTable(PdPDM.Table pdmTable, IEdmStructuredType edmStructuredType, PdLogger logger)
+        {
+            // If the current structred type has a base type, add it's base poperties first.
+            if (edmStructuredType.BaseType != null)
+            {
+                logger.Debug(string.Format(" Adding properties from base type {0}", edmStructuredType.BaseType.FullTypeName()));
+                AddColumsToTable(pdmTable, edmStructuredType.BaseType, logger);
+            }
+
+            // Loop over the declared properties.
+            foreach (IEdmProperty edmProperty in edmStructuredType.DeclaredProperties)
+            {
+                logger.Debug(string.Format(" -Property[Name={0}; PropertyKind={1}; Type={2}]", edmProperty.Name, Enum.GetName(typeof(EdmPropertyKind), edmProperty.PropertyKind), edmProperty.Type.FullName()));
+
+                // Only add columns for properties which are structural.
+                if (edmProperty.PropertyKind.Equals(EdmPropertyKind.Structural))
+                {
+                    // Create a new columns for the property.
+                    PdPDM.Column pdmColumn = (PdPDM.Column)pdmTable.Columns.CreateNew();
+                    pdmColumn.Name = edmProperty.Name;
+                    pdmColumn.SetNameToCode();
+
+                    // If the EDM property is part of the key, set the Primary indicator to true.
+                    if (edmProperty.IsKey())
+                        pdmColumn.Primary = true;
+
+                    // If the type is set, update the column.
+                    if (edmProperty.Type != null)
+                    {
+                        SetColumnType(pdmColumn, edmProperty.Type, logger);
+                    }
+
+                    // Add the new columns to the columns collection.
+                    pdmTable.Columns.Add(pdmColumn);
+                }
+            }
+        }
+
+        public static PdPDM.Package GetOrCreatePackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
+        {
+            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
+            // If the package is found, return it.
+            if (pdmPackageObject != null)
+            {
+                return (PdPDM.Package)pdmPackageObject;
+            }
+            // If the package wasn't found, create it.
+            else
+            {
+                PdPDM.Package pdmPackage = (PdPDM.Package)pdmModel.Packages.CreateNew();
+                pdmPackage.Name = packageNameToFind;
+                pdmPackage.SetNameToCode();
+                pdmModel.Packages.Add(pdmPackage);
+                return pdmPackage;
+            }
+
+        }
+
+        public static PdPDM.Package GetPackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
+        {
+            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
+            // If the package is found, return it.
+            if (pdmPackageObject != null)
+            {
+                return (PdPDM.Package)pdmPackageObject;
+            }
+            // If the package wasn't found, return null.
+            return null;
+
+        }
+
+        public static PdPDM.Table GetTable(PdPDM.BasePackage model, string tableNameToFind)
+        {
+            // Find the table in the model.
+            var tableObject = model.FindChildByName(tableNameToFind, (int)PdPDM.PdPDM_Classes.cls_Table);
+            if (tableObject != null)
+                return (PdPDM.Table)tableObject;
+
+            // If the table wasn't found, return null.
+            return null;
+        }
+
+        public static PdPDM.View GetView(PdPDM.BasePackage model, string viewNameToFind)
+        {
+            // Find the view in the model.
+            var viewObject = model.FindChildByName(viewNameToFind, (int)PdPDM.PdPDM_Classes.cls_View);
+            if (viewObject != null)
+                return (PdPDM.View)viewObject;
+
+            // If the view wasn't found, return null.
+            return null;
         }
 
         /// <summary>
@@ -253,6 +499,12 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         break;
                 }
             }
+            // If the type is an Enum, set the corresponding domain.
+            //else if (edmType.IsEnum())
+            //{
+            //    logger.Debug("The datatype is an Enum type, so translating to PDM domain.");
+            //    logger.Debug(string.Format(" -Enum={0}", edmType.FullName()));
+            //}
         }
     }
 }

--- a/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
+++ b/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
@@ -122,8 +122,12 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         // Set the parent table and role.
                         tableRef.ParentTable = targetedTypeTable;
                         tableRef.ParentRole = navProp.Name;
+
                         // Add the reference to the child table.
                         typeTable.OutReferences.Add(tableRef);
+
+                        // Empty the joins list (by default it is populated.
+                        tableRef.Joins.Clear();
                     }
                 }
 
@@ -208,7 +212,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                             }
                             else
                             {
-                                logger.Debug(" -Creating table reference:");
+                                logger.Debug(" -Creating view reference:");
                                 logger.Debug(string.Format("  -TargetView={0}", targetView.Name));
                                 PdPDM.ViewReference viewReference = (PdPDM.ViewReference)pdmEntitySetPackage.ViewReferences.CreateNew();
                                 viewReference.Name = string.Format("{0} > {1} : {2}", currentView.Name, targetView.Name, navigationPropertyBinding.NavigationProperty.Name);
@@ -216,95 +220,16 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                                 // Set the parent to the view.
                                 viewReference.Object2 = targetView;
                                 viewReference.ParentRole = navigationPropertyBinding.NavigationProperty.Name;
+
                                 // Add the reference to the view.
                                 currentView.OutViewReferences.Add(viewReference);
+
+                                // Empty the joins list (by default it is populated.
+                                viewReference.Joins.Clear();
                             }
                         }
                     }
                 }
-
-                //foreach (Tuple<IEdmEntityContainerElement, IEdmNavigationPropertyBinding> edmNavigationPropertyBindingTuple in model.EntityContainer.GetNavigationPropertyBindings())
-                //{
-                //    IEdmNavigationPropertyBinding edmNavigationPropertyBinding = edmNavigationPropertyBindingTuple.Item2;
-                //    IEdmNavigationProperty edmNavigationProperty = edmNavigationPropertyBinding.NavigationProperty;
-                //    string targetViewName = edmNavigationPropertyBinding.Target.Name;
-                //    logger.Debug(string.Format("Found navigation property binding '{0}'; Target={1}; Type={2}", edmNavigationProperty.Name, targetViewName, Enum.GetName(typeof(EdmTypeKind), edmNavigationPropertyBinding.Target.Type.TypeKind)));
-
-                //    // Represents a type implementing Microsoft.OData.Edm.IEdmCollectionType.
-                //    if (edmNavigationPropertyBinding.Target.Type.TypeKind.Equals(EdmTypeKind.Collection))
-                //    {
-                //        IEdmCollectionType collectionType = (IEdmCollectionType)edmNavigationPropertyBinding.Target.Type;
-                //        logger.Debug(string.Format(" =IEdmCollection[ElementType={0}", Enum.GetName(typeof(EdmTypeKind), collectionType.ElementType.TypeKind())));
-                //    }
-
-                    //PdPDM.View targetView = GetView(pdmModel, targetViewName);
-                    //if (targetView == null)
-                    //{
-                    //    logger.Error(string.Format("The target view '{0}' was not found!", targetViewName));
-                    //    throw new PdODataException("The target view was not found!");
-                    //}
-
-                    //// If the type is not set, skip this property.
-                    //string foreignEntityName = edmNavigationProperty.ToEntityType().Name;
-                    //logger.Debug(string.Format("Found foreign entity {0}", foreignEntityName));
-
-                    //PdPDM.View foreignView = GetView(pdmModel, foreignEntityName);
-                    //if (foreignView == null)
-                    //{
-                    //    logger.Error(string.Format("The foreign view '{0}' was not found!", foreignEntityName));
-                    //    throw new PdODataException("The foreign view was not found!");
-                    //}
-
-                    //PdPDM.ViewReference fkReference = (PdPDM.ViewReference)targetView.OutViewReferences.CreateNew();
-                    //fkReference.Name = edmNavigationProperty.Name;
-                    //fkReference.SetNameToCode();
-
-                    //foreach (EdmReferentialConstraintPropertyPair referentialConstraintPropertyPair in ((IEdmNavigationProperty)edmProperty).ReferentialConstraint.PropertyPairs)
-                    //{
-                    //    IEdmStructuralProperty localProperty = referentialConstraintPropertyPair.DependentProperty;
-                    //    IEdmStructuralProperty foreignProperty = referentialConstraintPropertyPair.PrincipalProperty;
-                    //    logger.Debug(string.Format("Found referential constraint property pair for local property {0} to foreign property {1}", localProperty.Name, foreignProperty.Name));
-
-                    //    PdPDM.Column localColumn = null;
-                    //    // Find the local PDM column.
-                    //    foreach (PdPDM.Column pdmColumn in pdmTable.Columns)
-                    //    {
-                    //        if (pdmColumn.Name.Equals(localProperty.Name))
-                    //        {
-                    //            localColumn = pdmColumn;
-                    //            break;
-                    //        }
-                    //    }
-                    //    if (localColumn == null)
-                    //    {
-                    //        logger.Error("The local column was not found!");
-                    //        throw new PdODataException("The local column was not found!");
-                    //    }
-
-                    //    PdPDM.Column foreignColumn = null;
-                    //    // Find the foreign PDM column.
-                    //    foreach (PdPDM.Column pdmColumn in foreignPdmTable.Columns)
-                    //    {
-                    //        if (pdmColumn.Name.Equals(foreignProperty.Name))
-                    //        {
-                    //            foreignColumn = pdmColumn;
-                    //            break;
-                    //        }
-                    //    }
-                    //    if (foreignColumn == null)
-                    //    {
-                    //        logger.Error("The foreign column was not found!");
-                    //        throw new PdODataException("The foreign column was not found!");
-                    //    }
-
-                    //    PdPDM.ReferenceJoin referenceJoin = (PdPDM.ReferenceJoin)fkReference.Joins.CreateNew();
-                    //    referenceJoin.ChildTableColumn = localColumn;
-                    //    referenceJoin.ParentTableColumn = foreignColumn;
-                    //    fkReference.Joins.Add(referenceJoin);
-                    //}
-
-                    //targetView.OutViewReferences.Add(fkReference);
-                //}
 
             }
             // If an error occurred while trying to parse the edm model, log the error(s).

--- a/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
+++ b/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
@@ -61,7 +61,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                     logger.Debug(string.Format(" {0}[Name={1}; Namespace={2}]", Enum.GetName(typeof(EdmTypeKind), structuredTypeElement.TypeKind), structuredTypeElement.Name, structuredTypeElement.Namespace));
 
                     // Get or create the package for the entity type.
-                    PdPDM.Package pdmTypePackage = GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
+                    PdPDM.Package pdmTypePackage = PdHelper.GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
 
                     // Create a new PDM table object for the EntityType.
                     PdPDM.Table pdmTypeTable = (PdPDM.Table)pdmTypePackage.Tables.CreateNew();
@@ -80,13 +80,13 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                 foreach (IEdmSchemaType structuredTypeElement in structuredTypeElements)
                 {
                     // Find the table which represents the underlying type.
-                    PdPDM.Package pdmEntityTypePackage = GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
+                    PdPDM.Package pdmEntityTypePackage = PdHelper.GetOrCreatePackage(pdmModel, structuredTypeElement.Namespace);
                     if (pdmEntityTypePackage == null)
                     {
                         logger.Error(string.Format("The type package '{0}' was not found!", structuredTypeElement.Namespace));
                         throw new PdODataException("The type package was not found!");
                     }
-                    PdPDM.Table typeTable = GetTable(pdmEntityTypePackage, structuredTypeElement.Name);
+                    PdPDM.Table typeTable = PdHelper.GetTable(pdmEntityTypePackage, structuredTypeElement.Name);
                     if (typeTable == null)
                     {
                         logger.Error(string.Format("The type table '{0}' was not found!", structuredTypeElement.Name));
@@ -100,13 +100,13 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
 
                         IEdmEntityType targetedEntityType = navProp.ToEntityType();
                         // Find the table which represents the targeted type.
-                        PdPDM.Package pdmTargetEntityTypePackage = GetOrCreatePackage(pdmModel, targetedEntityType.Namespace);
+                        PdPDM.Package pdmTargetEntityTypePackage = PdHelper.GetOrCreatePackage(pdmModel, targetedEntityType.Namespace);
                         if (pdmTargetEntityTypePackage == null)
                         {
                             logger.Error(string.Format("The targeted type package '{0}' was not found!", targetedEntityType.Namespace));
                             throw new PdODataException("The targeted type package was not found!");
                         }
-                        PdPDM.Table targetedTypeTable = GetTable(pdmTargetEntityTypePackage, targetedEntityType.Name);
+                        PdPDM.Table targetedTypeTable = PdHelper.GetTable(pdmTargetEntityTypePackage, targetedEntityType.Name);
                         if (targetedTypeTable == null)
                         {
                             logger.Error(string.Format("The targeted type table '{0}' was not found!", targetedEntityType.Name));
@@ -144,19 +144,19 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
 
                     // Now a table is created for the EntityType, we create a view for the EntitySet.
                     // Find the schema to entity type belongs to, so the table can be added in the right package.
-                    PdPDM.Package pdmEntitySetPackage = GetOrCreatePackage(pdmModel, edmEntitySet.Container.Namespace);
+                    PdPDM.Package pdmEntitySetPackage = PdHelper.GetOrCreatePackage(pdmModel, edmEntitySet.Container.Namespace);
                     PdPDM.View pdmView = (PdPDM.View)pdmEntitySetPackage.Views.CreateNew();
                     pdmView.Name = edmEntitySet.Name;
                     pdmView.SetNameToCode();
 
                     // Find the table which represents the underlying type.
-                    PdPDM.Package pdmEntityTypePackage = GetOrCreatePackage(pdmModel, entityType.Namespace);
+                    PdPDM.Package pdmEntityTypePackage = PdHelper.GetOrCreatePackage(pdmModel, entityType.Namespace);
                     if (pdmEntityTypePackage == null)
                     {
                         logger.Error(string.Format("The type package '{0}' was not found!", entityType.Namespace));
                         throw new PdODataException("The type package was not found!");
                     }
-                    PdPDM.Table typeTable = GetTable(pdmEntityTypePackage, entityType.Name);
+                    PdPDM.Table typeTable = PdHelper.GetTable(pdmEntityTypePackage, entityType.Name);
                     if (typeTable == null)
                     {
                         logger.Error(string.Format("The type table '{0}' was not found!", entityType.Name));
@@ -176,7 +176,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                     logger.Debug(string.Format(" EntitySet[ContainerElementKind={0}; Name={1}; Namespace={2}]", Enum.GetName(typeof(EdmContainerElementKind), edmEntitySet.ContainerElementKind), edmEntitySet.Name, edmEntitySet.Container.Namespace));
 
                     // Get the package for the view.
-                    PdPDM.Package pdmEntitySetPackage = GetPackage(pdmModel, edmEntitySet.Container.Namespace);
+                    PdPDM.Package pdmEntitySetPackage = PdHelper.GetPackage(pdmModel, edmEntitySet.Container.Namespace);
                     if (pdmEntitySetPackage == null)
                     {
                         logger.Error(string.Format("The current package '{0}' was not found!", edmEntitySet.Container.Namespace));
@@ -186,7 +186,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         logger.Debug(string.Format(" -Package={0}", pdmEntitySetPackage.Name));
                     }
 
-                    PdPDM.View currentView = GetView(pdmEntitySetPackage, edmEntitySet.Name);
+                    PdPDM.View currentView = PdHelper.GetView(pdmEntitySetPackage, edmEntitySet.Name);
                     if (currentView == null)
                     {
                         logger.Error(string.Format("The current view '{0}' was not found!", edmEntitySet.Name));
@@ -204,7 +204,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         // Represents a type implementing Microsoft.OData.Edm.IEdmCollectionType.
                         if (navigationPropertyBinding.Target.Type.TypeKind.Equals(EdmTypeKind.Collection))
                         {
-                            PdPDM.View targetView = GetView(pdmEntitySetPackage, navigationPropertyBinding.Target.Name);
+                            PdPDM.View targetView = PdHelper.GetView(pdmEntitySetPackage, navigationPropertyBinding.Target.Name);
                             if (targetView == null)
                             {
                                 logger.Error(string.Format("The target view '{0}' was not found!", navigationPropertyBinding.Target.Name));
@@ -281,80 +281,25 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
             }
         }
 
-        public static PdPDM.Package GetOrCreatePackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
-        {
-            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
-            // If the package is found, return it.
-            if (pdmPackageObject != null)
-            {
-                return (PdPDM.Package)pdmPackageObject;
-            }
-            // If the package wasn't found, create it.
-            else
-            {
-                PdPDM.Package pdmPackage = (PdPDM.Package)pdmModel.Packages.CreateNew();
-                pdmPackage.Name = packageNameToFind;
-                pdmPackage.SetNameToCode();
-                pdmModel.Packages.Add(pdmPackage);
-                return pdmPackage;
-            }
-
-        }
-
-        public static PdPDM.Package GetPackage(PdPDM.BasePackage pdmModel, string packageNameToFind)
-        {
-            var pdmPackageObject = pdmModel.FindChildByName(packageNameToFind, (int)PdPDM.PdPDM_Classes.cls_Package);
-            // If the package is found, return it.
-            if (pdmPackageObject != null)
-            {
-                return (PdPDM.Package)pdmPackageObject;
-            }
-            // If the package wasn't found, return null.
-            return null;
-
-        }
-
-        public static PdPDM.Table GetTable(PdPDM.BasePackage model, string tableNameToFind)
-        {
-            // Find the table in the model.
-            var tableObject = model.FindChildByName(tableNameToFind, (int)PdPDM.PdPDM_Classes.cls_Table);
-            if (tableObject != null)
-                return (PdPDM.Table)tableObject;
-
-            // If the table wasn't found, return null.
-            return null;
-        }
-
-        public static PdPDM.View GetView(PdPDM.BasePackage model, string viewNameToFind)
-        {
-            // Find the view in the model.
-            var viewObject = model.FindChildByName(viewNameToFind, (int)PdPDM.PdPDM_Classes.cls_View);
-            if (viewObject != null)
-                return (PdPDM.View)viewObject;
-
-            // If the view wasn't found, return null.
-            return null;
-        }
-
         /// <summary>
         /// Function to get the Sql data type based on a Edm primitive kind.
         /// Used: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/ef/sqlclient-for-ef-types
         /// </summary>
-        /// <param name="edmPrimitiveType"></param>
+        /// <param name="pdmColumn"></param>
+        /// <param name="edmType"></param>
+        /// <param name="logger"></param>
         /// <returns></returns>
         public static void SetColumnType(PdPDM.Column pdmColumn, IEdmTypeReference edmType, PdLogger logger)
         {
-            logger.Debug(string.Format(" -SetColumnType[ColumnName={0};EdmType={1}]", pdmColumn.Name, edmType.FullName()));
-
             // Set the Mandatory property as the inverse of IsNullable.
             pdmColumn.Mandatory = !edmType.IsNullable;
 
             // Translate the DataType if the edm type is a primitive.
             if (edmType.IsPrimitive())
             {
-                logger.Debug("The datatype is a primitive type, so translating to PDM datatype.");
                 switch (edmType.PrimitiveKind())
                 {
+                    // In OData V4 there is no "IsFixedLength" property on the binary type, so we can't differentiate a varbinary from binary.
                     case EdmPrimitiveTypeKind.Binary:
                         pdmColumn.DataType = "varbinary";
                         IEdmBinaryTypeReference edmBinaryType = edmType.AsBinary();
@@ -432,6 +377,7 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                 logger.Debug("The datatype is an Enum type, so translating to PDM domain.");
                 string enumFullName = edmType.FullName();
                 logger.Debug(string.Format(" -Enum={0}", enumFullName));
+                // Find the domain for the enum type.
                 PdPDM.PhysicalDomain enumDomain = (PdPDM.PhysicalDomain)((PdPDM.Model)pdmColumn.Model).FindChildByName(enumFullName, (int)PdPDM.PdPDM_Classes.cls_PhysicalDomain);
                 if (enumDomain == null)
                 {

--- a/PowerDesigner_OData_AddIn/Register_Debug_AddIn.reg
+++ b/PowerDesigner_OData_AddIn/Register_Debug_AddIn.reg
@@ -4,5 +4,5 @@ Windows Registry Editor Version 5.00
 "Class"="CrossBreeze.Tools.PowerDesigner.AddIn.OData.PdODataAddIn"
 "Enable"="No"
 "Type"="ActiveX"
-"File"="C:\\GIT\\Repos\\CrossBreeze\\PowerDesigner-OData-AddIn\\PowerDesigner_OData_AddIn\\bin\\Debug\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
+"File"="C:\\GIT\\GitHub\\PowerDesigner-OData-AddIn\\PowerDesigner_OData_AddIn\\bin\\Debug\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
 "Registered"="yes"

--- a/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
+++ b/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
@@ -597,7 +597,7 @@
             "SharedLegacy" = "11:FALSE"
             "PackageAs" = "3:1"
             "Register" = "3:1"
-            "Exclude" = "11:FALSE"
+            "Exclude" = "11:TRUE"
             "IsDependency" = "11:TRUE"
             "IsolateTo" = "8:"
             }
@@ -968,7 +968,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:PowerDesigner OData Add-In"
         "ProductCode" = "8:{E2DE22AF-4625-4FAF-BB67-699174628967}"
-        "PackageCode" = "8:{DA9E538C-9517-4D73-A022-5E8F99B5CE0A}"
+        "PackageCode" = "8:{803B70B7-AAE7-4350-8A1C-3EEEE8C9A84A}"
         "UpgradeCode" = "8:{69527C48-8042-4FF6-B5BE-DDEAB055932C}"
         "AspNetVersion" = "8:"
         "RestartWWWService" = "11:FALSE"


### PR DESCRIPTION
Refactored OData V3 and V4 helpers to import Types as Tables, Enums as Domains, EntitySets as Views and navigation properties as references.
Updated setup project to exclude on the of the duplicate Http includes.