### PR TITLE
Fix for text field generate nvarchar without length

### DIFF
--- a/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
+++ b/PowerDesigner_OData_AddIn/PdODataV4Helper.cs
@@ -339,11 +339,16 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                 {
                     // In OData V4 there is no "IsFixedLength" property on the binary type, so we can't differentiate a varbinary from binary.
                     case EdmPrimitiveTypeKind.Binary:
-                        pdmColumn.DataType = "varbinary";
                         IEdmBinaryTypeReference edmBinaryType = edmType.AsBinary();
                         // Set the length, if known.
                         if (edmBinaryType.MaxLength.HasValue)
+                        {
+                            pdmColumn.DataType = "varbinary(%n)";
                             pdmColumn.Length = edmBinaryType.MaxLength.Value;
+                        } else
+                        {
+                            pdmColumn.DataType = "varbinary";
+                        }
                         break;
 
                     case EdmPrimitiveTypeKind.Boolean:
@@ -363,7 +368,14 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         break;
 
                     case EdmPrimitiveTypeKind.Decimal:
-                        pdmColumn.DataType = "decimal";
+                        // Set the datatype.
+                        if (edmType.AsDecimal().Precision.HasValue && edmType.AsDecimal().Scale.HasValue)
+                            pdmColumn.DataType = "decimal(%s, %p)";
+                        else if (edmType.AsDecimal().Scale.HasValue)
+                            pdmColumn.DataType = "decimal(%n)";
+                        else
+                            pdmColumn.DataType = "decimal";
+
                         // If the precision is set, copy it.
                         if (edmType.AsDecimal().Precision.HasValue)
                             pdmColumn.Precision = (short)edmType.AsDecimal().Precision.Value;
@@ -397,11 +409,17 @@ namespace CrossBreeze.Tools.PowerDesigner.AddIn.OData
                         break;
 
                     case EdmPrimitiveTypeKind.String:
-                        pdmColumn.DataType = "nvarchar";
                         IEdmStringTypeReference stringType = edmType.AsString();
                         // Set the length, if known.
                         if (stringType.MaxLength.HasValue)
+                        {
+                            pdmColumn.DataType = "nvarchar(%n)";
                             pdmColumn.Length = stringType.MaxLength.Value;
+                        }
+                        else
+                        {
+                            pdmColumn.DataType = "nvarchar";
+                        }
                         break;
 
                     case EdmPrimitiveTypeKind.TimeOfDay:

--- a/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
+++ b/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
@@ -972,7 +972,7 @@
         "UpgradeCode" = "8:{69527C48-8042-4FF6-B5BE-DDEAB055932C}"
         "AspNetVersion" = "8:"
         "RestartWWWService" = "11:FALSE"
-        "RemovePreviousVersions" = "11:FALSE"
+        "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:FALSE"
         "InstallAllUsers" = "11:TRUE"
         "ProductVersion" = "8:1.0.0"
@@ -1571,7 +1571,7 @@
         {
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_4B2D84A67F1E41BF9E6BD783A8AC40F9"
             {
-            "SourcePath" = "8:..\\PowerDesigner_OData_AddIn\\obj\\Release\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
+            "SourcePath" = "8:..\\PowerDesigner_OData_AddIn\\obj\\Debug\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_4FC4A2B1FA3648379E1C54E7E80501F8"

--- a/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
+++ b/PowerDesigner_OData_AddIn_Setup/PowerDesigner_OData_AddIn_Setup.vdproj
@@ -1571,7 +1571,7 @@
         {
             "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_4B2D84A67F1E41BF9E6BD783A8AC40F9"
             {
-            "SourcePath" = "8:..\\PowerDesigner_OData_AddIn\\obj\\Debug\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
+            "SourcePath" = "8:..\\PowerDesigner_OData_AddIn\\obj\\Release\\CrossBreeze.Tools.PowerDesigner.AddIn.OData.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_4FC4A2B1FA3648379E1C54E7E80501F8"


### PR DESCRIPTION
- Added placeholders in DataType for length, precision and scale where needed to solve issue for setting these properties (fix for #17).
- Solved null error on entities without a key in the V3 helper.
- Enabled uninstalling of previous version in installer (hopefully fix for #12).